### PR TITLE
Django Girls cartagena

### DIFF
--- a/web/stories/django-girls-cartagena.rst
+++ b/web/stories/django-girls-cartagena.rst
@@ -23,10 +23,11 @@
 
 ----
 
-¡Queremos animar a más mujeres a dominar la web! Es por eso que desde
-`Argentina en Python <https://argentinaenpython.com>`_ junto a `Python
-Cartagena <https://www.meetup.com/Python-Django-CTG/>`_ y `Django Girls Colombia 
-<https://www.facebook.com/djangogirlscolombia>`_ estamos
+¡Queremos animar a más mujeres a dominar la web! Es por eso que desde 
+`Django Girls Colombia <https://www.facebook.com/djangogirlscolombia>`_
+ junto a `Python Cartagena <https://www.meetup.com/Python-Django-CTG/>`_ 
+con el apoyo de `Argentina en Python <https://argentinaenpython.com>`_ y la comunidad
+de `Python Colombia <https://www.python-colombia.org>`_ estamos
 organizando un taller en el cual podrás construir tu propio sitio web
 *desde cero* en un día. Además, vamos a utilizar todas las
 herramientas que programadores profesionales utilizan diariamente. ¡Y

--- a/web/stories/django-girls-cartagena.rst
+++ b/web/stories/django-girls-cartagena.rst
@@ -91,14 +91,12 @@ mujer con vos que también realice el taller [#]_.
 * Fecha: Sábado 14 de Octubre de 2017 de 8:30hs (¡puntual!) a 19:00hs.
 
 .. template:: iframe
-   :src: http://www.openstreetmap.org/export/embed.html?bbox=-75.53744316101076%2C10.41330168615115%2C-75.52240133285524%2C10.425942878083998&amp;layer=mapnik
+   :src: https://www.openstreetmap.org/export/embed.html?bbox=-75.53744316101076%2C10.41330168615115%2C-75.52240133285524%2C10.425942878083998&amp;layer=mapnik
 
 
 .. sidebar:: Contacto
 
-   Cualquier duda que tengas sobre el taller, nos puedes escribir a
-   `argentinaenpython@openmailbox.org
-   <mailto:argentinaenpython@openmailbox.org>`_ y `djangogirlscolombia@gmail.com <mailto:djangogirlscolombia@gmail.com>`_, para ponerte en contacto con nosotros.
+   Cualquier duda que tengas sobre el taller, nos puedes escribir a `djangogirlscolombia@gmail.com <mailto:djangogirlscolombia@gmail.com>`_, para ponerte en contacto con nosotros.
 
    .. image:: organizadores.png
       :align: center

--- a/web/stories/django-girls-cartagena.rst
+++ b/web/stories/django-girls-cartagena.rst
@@ -23,15 +23,9 @@
 
 ----
 
-¡Queremos animar a más mujeres a dominar la web! Es por eso que desde 
-`Django Girls Colombia <https://www.facebook.com/djangogirlscolombia>`_
- junto a `Python Cartagena <https://www.meetup.com/Python-Django-CTG/>`_ 
-con el apoyo de `Argentina en Python <https://argentinaenpython.com>`_ y la comunidad
-de `Python Colombia <https://www.python-colombia.org>`_ estamos
-organizando un taller en el cual podrás construir tu propio sitio web
-*desde cero* en un día. Además, vamos a utilizar todas las
-herramientas que programadores profesionales utilizan diariamente. ¡Y
-de una manera muy sencilla!
+¡Queremos animar a más mujeres a dominar la web! Es por eso que desde `Django Girls Colombia <https://www.facebook.com/djangogirlscolombia>`_ junto a `Python Cartagena <https://www.meetup.com/Python-Django-CTG/>`_ con el apoyo de `Argentina en Python <https://argentinaenpython.com>`_ y la comunidad de `Python Colombia <https://www.python-colombia.org>`_ estamos
+organizando un taller en el cual podrás construir tu propio sitio web *desde cero* en un día. Además, vamos a utilizar todas las
+herramientas que programadores profesionales utilizan diariamente. ¡Y de una manera muy sencilla!
 
 .. class:: lead
 


### PR DESCRIPTION
Cambios realizados
* En el mapa se cambio http por https
* En la sección de contacto se dejo solo el email de djangogirlscolombia@gmail.com
* se indico en el 1er parrafo que Argentina en Python Apoya y no organiza.